### PR TITLE
Bugfix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <head>
+<title>Weather App</title>
+<meta charset="utf-8">
 <link href='https://fonts.googleapis.com/css?family=Quicksand:300,400,700' rel='stylesheet' type='text/css'>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" type="text/css" href="main.css">

--- a/main.css
+++ b/main.css
@@ -29,7 +29,6 @@
 .row:hover {
   display: flex;
   flex: 1.5;
-  transition: 1s;
   justify-content: center;
   align-content: center;
 }
@@ -41,6 +40,7 @@
   align-content: center;
   font-family: 'Quicksand', sans-serif;
   font-size: 5vw;
+  transition: 1s;
 }
 
 

--- a/main.js
+++ b/main.js
@@ -1,13 +1,13 @@
 $(document).ready(function() {
   var api;
 
-  var urlGeo = "http://ip-api.com/json";
+  var urlGeo = "https://freegeoip.net/json/";
   $.getJSON(urlGeo, function(getGeo) {
     //console.log("Success with urlGeo: ");
-    var lat = getGeo.lat;
-    var lon = getGeo.lon;
+    var lat = getGeo.latitude;
+    var lon = getGeo.longitude;
     var city = getGeo.city;
-    var region = getGeo.region;
+    var region = getGeo.region_code;
     var cityRegion = "in " + city + ", " + region;
     api = 'http://api.openweathermap.org/data/2.5/weather?lat=' + lat + '&lon=' + lon + '&appid=52c662f3c521e182bbc01e8ca55a3944';
     //console.log("Success with api: " + api);


### PR DESCRIPTION
Move transition setting to the .row itself so that the transition doesn't jump abruptly when moving from one row to the next.

Use https version of freegeoip.net instead of ip-api.com which does not have an https version.

Unfortunately the openweathermap.org api only offers an http version to paying customers so that's still a problem.
